### PR TITLE
perf: client.go updated (temp location updated)

### DIFF
--- a/client.go
+++ b/client.go
@@ -74,7 +74,7 @@ func NewClient(cfg ClientConfig) (client Client, err error) {
 
 	blocklist := getBlocklist()
 	torrentConfig := torrent.NewDefaultClientConfig()
-	torrentConfig.DataDir = os.TempDir()
+	torrentConfig.DataDir = os.TempDir() + "/go-peerflix"
 	torrentConfig.NoUpload = !cfg.Seed
 	torrentConfig.DisableTCP = !cfg.TCP
 	torrentConfig.ListenPort = cfg.TorrentPort


### PR DESCRIPTION
The temp location for downloaded files changed from $TMPDIR to $TMPDIR/go-peerflix (the blocklist is still saved as it was, to $TMPDIR/go-peerflix-blocklist.gz)